### PR TITLE
Exclude tests from package tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,23 @@
     "url": "https://github.com/wix/kampos/issues"
   },
   "homepage": "https://wix.github.io/kampos",
+  "files": [
+    "demo/",
+    "docs/",
+    "src/",
+    ".editorconfig",
+    ".gitignore",
+    ".travis.yml",
+    "CHANGELOG.md",
+    "documentation.yml",
+    "index.html",
+    "index.js",
+    "kampos.svg",
+    "LICENSE",
+    "package.json",
+    "README.md",
+    "rollup.config.js"
+  ],
   "devDependencies": {
     "@babel/core": "^7.13.16",
     "ava": "^3.15.0",


### PR DESCRIPTION
When users of library install this package as dependency they don't need autogenerated resources for tests.
Also those files generated with restricted symbols (`|`) on Windows.